### PR TITLE
feat: `merge` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1064,10 +1064,10 @@ impl GitChain {
     }
 
     fn rebase(&self, chain_name: &str, step_rebase: bool, ignore_root: bool) -> Result<(), Error> {
-        switch (self.preliminary_checks(chain_name)) {
+        match self.preliminary_checks(chain_name) {
             Ok(_) => {}
             Err(e) => {
-                return Err(Error::from_str(&format!("🛑 Unable to rebase chain: {}", chain_name)));
+                return Err(Error::from_str(&format!("🛑 Unable to rebase chain {}: {}", chain_name, e)));
             }
         }
 
@@ -1510,7 +1510,7 @@ impl GitChain {
     }
 
     fn merge_chain(&self, chain_name: &str) -> Result<(), Error> {
-        switch (self.preliminary_checks(chain_name)) {
+        match self.preliminary_checks(chain_name) {
             Ok(_) => {}
             Err(e) => {
                 return Err(Error::from_str(&format!("🛑 Unable to merge chain {}: {}", chain_name, e)));


### PR DESCRIPTION
In my personal workflow, I like to rebase as long as I'm working privately, but after getting reviews on PRs, I typically will only merge in upstream changes, to avoid breaking the history of the PR page. So, I would have use for a `merge` command that cascades merges up a chain. Here's how it looked after a brief test:
```
❯ glog
*   4b0d7cc (HEAD -> test-chain/3) Merge branch 'test-chain/2' into test-chain/3
|\
| *   0ccb636 (test-chain/2) Merge branch 'test-chain/1' into test-chain/2
| |\
| | * 66941c4 (test-chain/1) test chain edit 1b
* | | cac2d95 test chain edit 3
|/ /
* / fd17589 test chain edit 2
|/
* 2802e5d test chain edit 1
* ad28b75 (fork/fork_master, fork_master) fix alias instructions
```